### PR TITLE
Add debug dump GUC for vchordrq searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,10 +151,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo_toml"
@@ -264,6 +291,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +338,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -327,6 +382,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -421,6 +486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +521,16 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -755,6 +840,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +877,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray-npy"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85776816e34becd8bd9540818d7dc77bf28307f3b3dcc51cc82403c6931680c"
+dependencies = [
+ "byteorder",
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "py_literal",
+ "zip",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +920,43 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -846,6 +1014,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +1087,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "uuid",
 ]
 
@@ -935,7 +1147,7 @@ dependencies = [
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "toml 0.8.23",
  "url",
  "winapi",
@@ -968,7 +1180,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "thiserror",
+ "thiserror 2.0.12",
  "unescape",
 ]
 
@@ -1042,6 +1254,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1325,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -1263,6 +1494,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,11 +1615,31 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1480,6 +1742,18 @@ name = "toml_writer"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unescape"
@@ -1623,6 +1897,8 @@ dependencies = [
  "always_equal",
  "distance",
  "half 2.6.0",
+ "ndarray",
+ "ndarray-npy",
  "pin-project",
  "rabitq",
  "rand",
@@ -1640,6 +1916,12 @@ dependencies = [
  "distance",
  "simd",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2057,4 +2339,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "flate2",
+ "thiserror 1.0.69",
 ]

--- a/crates/vchordrq/Cargo.toml
+++ b/crates/vchordrq/Cargo.toml
@@ -17,6 +17,8 @@ pin-project = "1.1"
 serde.workspace = true
 validator.workspace = true
 zerocopy.workspace = true
+ndarray = "0.15"
+ndarray-npy = "0.8"
 
 [dev-dependencies]
 rand.workspace = true

--- a/src/index/gucs.rs
+++ b/src/index/gucs.rs
@@ -77,6 +77,8 @@ static VCHORDRQ_IO_RERANK: GucSetting<PostgresIo> = GucSetting::<PostgresIo>::ne
     PostgresIo::ReadStream,
 );
 
+static VCHORDRQ_DEBUG_DUMP: GucSetting<Option<CString>> = GucSetting::<Option<CString>>::new(None);
+
 pub fn init() {
     GucRegistry::define_bool_guc(
         c"vchordrq.enable_scan",
@@ -155,6 +157,14 @@ pub fn init() {
         c"`io_rerank` argument of vchordrq.",
         c"`io_rerank` argument of vchordrq.",
         &VCHORDRQ_IO_RERANK,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_string_guc(
+        c"vchordrq.debug_dump",
+        c"`debug_dump` argument of vchordrq.",
+        c"`debug_dump` argument of vchordrq.",
+        &VCHORDRQ_DEBUG_DUMP,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -330,4 +340,12 @@ pub fn vchordrq_io_rerank() -> Io {
         #[cfg(any(feature = "pg17", feature = "pg18"))]
         PostgresIo::ReadStream => Io::Stream,
     }
+}
+
+pub fn vchordrq_debug_dump() -> Option<String> {
+    VCHORDRQ_DEBUG_DUMP
+        .get()
+        .and_then(|s| s.to_str().ok())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
 }

--- a/src/index/vchordrq/scanners/default.rs
+++ b/src/index/vchordrq/scanners/default.rs
@@ -13,6 +13,7 @@
 // Copyright (c) 2025 TensorChord Inc.
 
 use crate::index::fetcher::*;
+use crate::index::gucs::vchordrq_debug_dump;
 use crate::index::opclass::Sphere;
 use crate::index::scanners::{Io, SearchBuilder};
 use crate::index::vchordrq::algo::*;
@@ -115,6 +116,7 @@ impl SearchBuilder for DefaultBuilder {
             index,
             hints: Hints::default().full(true),
         };
+        let debug_dump = vchordrq_debug_dump();
         let f = move |(distance, payload)| (opfamily.output(distance), payload);
         let iter: Box<dyn Iterator<Item = (f32, NonZero<u64>)>> =
             match (opfamily.vector_kind(), opfamily.distance_kind()) {
@@ -135,6 +137,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_plain_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Simple => default_search::<_, Op>(
                             index,
@@ -144,6 +147,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_simple_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Stream => default_search::<_, Op>(
                             index,
@@ -153,6 +157,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_stream_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                     };
                     let method = how(index);
@@ -268,6 +273,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_plain_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Simple => default_search::<_, Op>(
                             index,
@@ -277,6 +283,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_simple_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Stream => default_search::<_, Op>(
                             index,
@@ -286,6 +293,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_stream_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                     };
                     let method = how(index);
@@ -401,6 +409,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_plain_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Simple => default_search::<_, Op>(
                             index,
@@ -410,6 +419,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_simple_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Stream => default_search::<_, Op>(
                             index,
@@ -419,6 +429,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_stream_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                     };
                     let method = how(index);
@@ -534,6 +545,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_plain_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Simple => default_search::<_, Op>(
                             index,
@@ -543,6 +555,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_simple_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                         Io::Stream => default_search::<_, Op>(
                             index,
@@ -552,6 +565,7 @@ impl SearchBuilder for DefaultBuilder {
                             bump,
                             make_h1_plain_prefetcher,
                             make_h0_stream_prefetcher,
+                            debug_dump.as_deref(),
                         ),
                     };
                     let method = how(index);

--- a/src/index/vchordrq/scanners/maxsim.rs
+++ b/src/index/vchordrq/scanners/maxsim.rs
@@ -13,6 +13,7 @@
 // Copyright (c) 2025 TensorChord Inc.
 
 use crate::index::fetcher::*;
+use crate::index::gucs::vchordrq_debug_dump;
 use crate::index::scanners::{Io, SearchBuilder};
 use crate::index::vchordrq::algo::*;
 use crate::index::vchordrq::filter::filter;
@@ -105,6 +106,7 @@ impl SearchBuilder for MaxsimBuilder {
             index,
             hints: Hints::default().full(true),
         };
+        let debug_dump = vchordrq_debug_dump();
         let n = vectors.len();
         let accu_map = |(Reverse(distance), AlwaysEqual(payload))| (distance, payload);
         let rough_map = |((_, AlwaysEqual(rough)), AlwaysEqual(&mut (payload, ..))): (
@@ -129,6 +131,7 @@ impl SearchBuilder for MaxsimBuilder {
                     .map(|vector| RandomProject::project(vector.as_borrowed()))
                     .collect::<Vec<_>>();
                 Box::new((0..n).map(move |i| {
+                    let dump_path = debug_dump.as_ref().map(|p| format!("{p}.{i}"));
                     let (results, estimation_by_threshold) = match options.io_search {
                         Io::Plain => maxsim_search::<_, Op>(
                             index,
@@ -139,6 +142,7 @@ impl SearchBuilder for MaxsimBuilder {
                             bump,
                             make_h1_plain_prefetcher.clone(),
                             make_h0_plain_prefetcher.clone(),
+                            dump_path.as_deref(),
                         ),
                         Io::Simple => maxsim_search::<_, Op>(
                             index,
@@ -149,6 +153,7 @@ impl SearchBuilder for MaxsimBuilder {
                             bump,
                             make_h1_plain_prefetcher.clone(),
                             make_h0_simple_prefetcher.clone(),
+                            dump_path.as_deref(),
                         ),
                         Io::Stream => maxsim_search::<_, Op>(
                             index,
@@ -159,6 +164,7 @@ impl SearchBuilder for MaxsimBuilder {
                             bump,
                             make_h1_plain_prefetcher.clone(),
                             make_h0_stream_prefetcher.clone(),
+                            dump_path.as_deref(),
                         ),
                     };
                     let (mut accu_set, mut rough_set) = (Vec::new(), Vec::new());
@@ -270,6 +276,7 @@ impl SearchBuilder for MaxsimBuilder {
                     .map(|vector| RandomProject::project(vector.as_borrowed()))
                     .collect::<Vec<_>>();
                 Box::new((0..n).map(move |i| {
+                    let dump_path = debug_dump.as_ref().map(|p| format!("{p}.{i}"));
                     let (results, estimation_by_threshold) = match options.io_search {
                         Io::Plain => maxsim_search::<_, Op>(
                             index,
@@ -280,6 +287,7 @@ impl SearchBuilder for MaxsimBuilder {
                             bump,
                             make_h1_plain_prefetcher.clone(),
                             make_h0_plain_prefetcher.clone(),
+                            dump_path.as_deref(),
                         ),
                         Io::Simple => maxsim_search::<_, Op>(
                             index,
@@ -290,6 +298,7 @@ impl SearchBuilder for MaxsimBuilder {
                             bump,
                             make_h1_plain_prefetcher.clone(),
                             make_h0_simple_prefetcher.clone(),
+                            dump_path.as_deref(),
                         ),
                         Io::Stream => maxsim_search::<_, Op>(
                             index,
@@ -300,6 +309,7 @@ impl SearchBuilder for MaxsimBuilder {
                             bump,
                             make_h1_plain_prefetcher.clone(),
                             make_h0_stream_prefetcher.clone(),
+                            dump_path.as_deref(),
                         ),
                     };
                     let (mut accu_set, mut rough_set) = (Vec::new(), Vec::new());


### PR DESCRIPTION
## Summary
- add `vchordrq.debug_dump` GUC and helper to expose optional debug dump path
- log centroid routing and ANN candidate data in `default_search` and `maxsim_search`
- allow scanners to pass debug dump path and write NPY files when set

## Testing
- `cargo test -p vchordrq` *(fails: `let` expressions in this position are unstable in crates/simd/build.rs)*


------
https://chatgpt.com/codex/tasks/task_e_689b733262e88329ace01398f987cff0